### PR TITLE
Add resources page, and link to openscapes.cloud

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -70,6 +70,7 @@ website:
       - href: blog.qmd
         text: Blog
       - contact.qmd
+      - resources.qmd
 
 format:
   html:

--- a/resources.qmd
+++ b/resources.qmd
@@ -1,0 +1,6 @@
+---
+title: "Resources"
+format: html
+---
+
+![](images/openscapes_hex.png){fig-alt="hexagonal Openscapes logo" fig-align="left" width="30"} [**openscapes.cloud**](https://openscapes.cloud) - A central location for Openscapes JupyterHub access, policies, and fledging information.


### PR DESCRIPTION
This is very bare-bones, perhaps we can add some contextual text at the top when we add more resources and thus a flavour of the type of content we have here?

Deploy preview: https://deploy-preview-67--nmfs-openscapes-preview.netlify.app/resources

Closes #65 