### PR TITLE
Update data academy for Spring 2026

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 _site/
 
 .DS_Store
+
+**/*.quarto_ipynb

--- a/data-academy.qmd
+++ b/data-academy.qmd
@@ -14,7 +14,7 @@ If you’re interested in participating, please add yourself to the [interest sh
 
 **Expected time commitment**: Weekly for 3 months: 2-3-hour chunks of learning time per week, plus optional 1 hour of support from a "help desk" and coworking.
 
-**When**: April 27 - August 28, 2026.
+**When**: April 20 - August 28, 2026.
 
 -   Mondays: Week’s lesson reminder received via email. Complete lesson on your own schedule.
 -   Wednesdays: Help desk, live demos of the material, and coworking with the Openscapes team alongside other participants (Optional, via Zoom).

--- a/data-academy.qmd
+++ b/data-academy.qmd
@@ -17,7 +17,7 @@ If you’re interested in participating, please add yourself to the [interest sh
 **When**: April 27 - August 28, 2026.
 
 -   Mondays: Week’s lesson reminder received via email. Complete lesson on your own schedule.
--   Wednesdays: Help desk and coworking with the Openscapes team alongside other participants (Optional, via Zoom).
+-   Wednesdays: Help desk, live demos of the material, and coworking with the Openscapes team alongside other participants (Optional, via Zoom).
 -   Asynchronous chat and Q&A in the dedicated Google Space.
 
 **Cost:** Free. There is no cost to staff or your center/office. This opportunity is supported by NOAA funding to Openscapes.

--- a/data-academy.qmd
+++ b/data-academy.qmd
@@ -4,7 +4,7 @@ title: "NMFS Openscapes Data Academy"
 
 The Data Academy is being led by Openscapes as part of the Fisheries Data Modernization Strategy. The goal of the Data Academy is to provide NOAA Fisheries staff with foundational data science skills in R, and to build a community of practice around data science and open & reproducible science.
 
-If you’re interested in participating, please add yourself to the [interest sheet](https://docs.google.com/spreadsheets/d/1Ot92fLTxiP8e3zZfdbF4lnfO8JtR9mhghQ049LoyL4w/edit?gid=0#gid=0). Deadline to apply is close of business April 10.
+If you’re interested in participating, please add yourself to the [interest sheet](https://docs.google.com/spreadsheets/d/1Ot92fLTxiP8e3zZfdbF4lnfO8JtR9mhghQ049LoyL4w/edit?gid=0#gid=0). **Deadline to apply is close of business April 10**.
 
 ## What is the Data Academy?
 

--- a/data-academy.qmd
+++ b/data-academy.qmd
@@ -10,7 +10,7 @@ If you’re interested in participating, please add yourself to the [interest sh
 
 **What:** You will learn R for data science through lessons on the [dataquest.io](http://dataquest.io) platform. See the [curriculum](#curriculum) below. The Data Academy is **asynchronous** so you can complete the lessons on your own schedule, and also **cohort-based** so you’ll get to know your colleagues and have accountability. The Openscapes team will provide support through optional **synchronous help desk hours and coworking** and a **dedicated Google Space** for help. A training certificate will be issued for each module completed.
 
-**Who**: FTEs and Affiliates from any Fisheries office are welcome to sign up.
+**Who**: FTEs and Affiliates from any Fisheries office or center are welcome to sign up.
 
 **Expected time commitment**: Weekly for 3 months: 2-3-hour chunks of learning time per week, plus optional 1 hour of support from a "help desk" and coworking.
 
@@ -31,14 +31,14 @@ Participants in the Data Academy Spring Cohort will complete two Skill Paths (vi
 #### [R Basics for Data Analysis](https://www.dataquest.io/path/r-basics-for-data-analysis/) (4 courses)
 
 -   [Introduction to Data Analysis in R](https://www.dataquest.io/course/intro-to-r-rewrite/) (weeks 1-3)
--   [Data Structures in R](https://www.dataquest.io/course/datastructure-in-r-rewrite/) (weeks 3-7)
--   [Control Flow, Iteration, and Functions in R](https://www.dataquest.io/course/intermediate-r/) (weeks 8-9)
--   BREAK WEEK - no new material, catch up on previous weeks, and/or explore other courses in the dataquest.io catalogue (week 10)
--   [Specialized Data Processing in R](https://www.dataquest.io/course/intermediate-r-part-two/) (weeks 11-12)
+-   [Data Structures in R](https://www.dataquest.io/course/datastructure-in-r-rewrite/) (weeks 3-8)
+-   [Control Flow, Iteration, and Functions in R](https://www.dataquest.io/course/intermediate-r/) (weeks 9-10)
+-   BREAK WEEK - no new material, catch up on previous weeks, and/or explore other courses in the dataquest.io catalogue (week 11)
+-   [Specialized Data Processing in R](https://www.dataquest.io/course/intermediate-r-part-two/) (weeks 12-13)
 
 #### [Data Visualization with R](https://www.dataquest.io/path/data-visualization-with-r/) (1 course)
 
--   [Introduction to Data Visualization in R](https://www.dataquest.io/course/r-data-viz/) (weeks 13-15)
+-   [Introduction to Data Visualization in R](https://www.dataquest.io/course/r-data-viz/) (weeks 14-16)
 
 During the Data Academy, you will have access to the [full dataquest.io catalogue of courses](https://www.dataquest.io/catalog/) in addition to the R Curriculum. If you have time after completing the curriculum for your certificates, we recommend the following additional courses:
 

--- a/data-academy.qmd
+++ b/data-academy.qmd
@@ -52,7 +52,7 @@ Participants receive a certificate for each of the Skills Paths that they comple
 
 **Who can participate?**
 
-FTEs & Affiliates. We aim to get representation from all NOAA Fisheries science centers, regional offices, and strategic initiatives.
+FTEs & Affiliates. We aim to get representation from all NOAA Fisheries science centers and regional offices.
 
 **What’s the minimum I need to know?**
 

--- a/data-academy.qmd
+++ b/data-academy.qmd
@@ -4,7 +4,7 @@ title: "NMFS Openscapes Data Academy"
 
 The Data Academy is being led by Openscapes as part of the Fisheries Data Modernization Strategy. The goal of the Data Academy is to provide NOAA Fisheries staff with foundational data science skills in R, and to build a community of practice around data science and open & reproducible science.
 
-If you’re interested in participating, please add yourself to the [interest sheet](https://docs.google.com/spreadsheets/d/1Ot92fLTxiP8e3zZfdbF4lnfO8JtR9mhghQ049LoyL4w/edit?gid=0#gid=0). **Deadline to apply is close of business April 10**.
+If you’re interested in participating, please add yourself to the [interest sheet](https://docs.google.com/spreadsheets/d/1Ot92fLTxiP8e3zZfdbF4lnfO8JtR9mhghQ049LoyL4w/edit?gid=0#gid=0). **Deadline to apply is close of business April 10, 2026**.
 
 ## What is the Data Academy?
 

--- a/data-academy.qmd
+++ b/data-academy.qmd
@@ -4,80 +4,43 @@ title: "NMFS Openscapes Data Academy"
 
 The Data Academy is being led by Openscapes as part of the Fisheries Data Modernization Strategy. The goal of the Data Academy is to provide NOAA Fisheries staff with foundational data science skills in R, and to build a community of practice around data science and open & reproducible science.
 
-The [Spring 2025 cohort] is complete, and the [Fall 2025 cohort] is currently underway. Due to the high level of interest, we plan to hold 2 additional cohorts in the next 12 months for other R learners. The [Data Academy cohorts 2025](https://docs.google.com/document/d/1iQY1JpUZ9Ku2xF_Qb3jwxrCqFFAGYXn0_VqECOOEM3Q/) doc outlines the plan for each cohort. 
-
-Applications are currently closed.
-
-<!--- [Sign up for spring 2025] by close of business **March 25, 2025** ⬢ [Sample email](https://docs.google.com/document/d/1HqktN5owu4rDCg37lh-eyDcw-wzsbRJ0eVrTfMN5eEQ/) to share announcement. --->
+If you’re interested in participating, please add yourself to the [interest sheet](https://docs.google.com/spreadsheets/d/1Ot92fLTxiP8e3zZfdbF4lnfO8JtR9mhghQ049LoyL4w/edit?gid=0#gid=0). Deadline to apply is close of business April 10.
 
 ## What is the Data Academy?
 
-**What:** You will learn R for data science through lessons on the [dataquest.io](http://dataquest.io) platform. See the [curriculum] below. The Data Academy is **asynchronous** so you can complete the lessons on your own schedule, and also **cohort-based** so you’ll get to know your colleagues and have accountability. The Openscapes team will provide support through optional **synchronous help desk hours and coworking** and a **dedicated Google Space** for help. A training certificate will be issued for each module completed.
+**What:** You will learn R for data science through lessons on the [dataquest.io](http://dataquest.io) platform. See the [curriculum](#curriculum) below. The Data Academy is **asynchronous** so you can complete the lessons on your own schedule, and also **cohort-based** so you’ll get to know your colleagues and have accountability. The Openscapes team will provide support through optional **synchronous help desk hours and coworking** and a **dedicated Google Space** for help. A training certificate will be issued for each module completed.
 
 **Who**: FTEs and Affiliates from any Fisheries office were welcomed to sign up.
 
-**Cost:** Free. There is no cost to staff or your center/office. This opportunity is supported by NOAA funding to Openscapes.
+**Expected time commitment**: Weekly for 3 months: 2-3-hour chunks of learning time per week, plus optional 1 hour of support from a "help desk" and coworking.
 
-## Fall 2025 Cohort
-
-The Fall Cohort is intended to be more self-directed and may include people who are new to R or have some R experience. Participants can choose their own learning paths based on their interests and needs, and/or choose to follow the same [curriculum] as those in the Spring cohort. You can see the suggested curriculum schedule for the Fall cohort in the [curriculum spreadsheet](https://docs.google.com/spreadsheets/d/1YdE_khWiEr46fgdUyAG7GUg6fGBEAgQ9RRl9ac__0hQ).
-
-**When:** Aug 18, 2025 - Apr 10, 2026. 
-
--   Complete lessons on your own schedule.
--   Wednesdays: Help desk with the Openscapes team alongside other participants (Optional, via Zoom).
--   Asynchronous chat and Q&A in the dedicated Google Space.
-
-### Sign up and Selection
-
-Fall 2025 NMFS Openscapes Champions can [sign up](https://docs.google.com/spreadsheets/d/1BEwSdFN95f8Y12MhQpiM4p3l3RHQeHoHeZsBu7WREfE/) to join by Jan 30, 2026.
-
-Particpants for the Fall cohort were selected from the waitlist of the Spring cohort. 
-
-## Spring 2025 Cohort
-
-The Spring Cohort was designed for absolute beginners to R, and covers the basics of R programming and data visualization. This was a great opportunity for those who were new to R or had limited experience with it. Paricipants followed the [curriculum] outlined below.
-
-**Expected time commitment**: Weekly for 3 months: 2-hour chunks of learning time, plus optional 1 hour of support from a "help desk" and coworking.
-
-**When**: April 14 - August 14, 2025.
+**When**: April 27 - August 28, 2026.
 
 -   Mondays: Week’s lesson reminder received via email. Complete lesson on your own schedule.
 -   Wednesdays: Help desk and coworking with the Openscapes team alongside other participants (Optional, via Zoom).
 -   Asynchronous chat and Q&A in the dedicated Google Space.
 
-### Sign up
-
-<!-- If you’re interested in participating, please add yourself to the [interest sheet](https://docs.google.com/spreadsheets/d/1Kzl6akKd030oz-qPzBrikVbHyrjOLR7EgG5emSDkq9Q/edit?usp=drive_link). Deadline to apply is close of business March 24. -->
-
-**As this cohort is complete, applications are closed.**
-
-### Selection
-
-The ~~40~~ 80* available spots were distributed across centers and offices. Participants were selected by the Openscapes team with input from NMFS Open Science staff and NMFS Openscapes Mentors.
-
-::: {.callout-note}
-*Due to high demand, we ran the equivalent of two cohorts simultaneously in Spring 2025, for a total of ~80 participants. The [second cohort](#fall-2025-cohort) in the Fall is for those with some R experience, and will be more self-directed.
-:::
+**Cost:** Free. There is no cost to staff or your center/office. This opportunity is supported by NOAA funding to Openscapes.
 
 ## Curriculum
 
 Dataquest offers many different "Learning Paths", including [Career Paths](https://www.dataquest.io/data-science-courses/career-paths/) and [Skill Paths](https://www.dataquest.io/data-science-courses/career-paths/). These Paths are composed of one or more courses, each of which consist of several modules.
 
-Participants in the Data Academy Spring Cohort completed two Skill Paths (view as [weekly spreadsheet](https://docs.google.com/spreadsheets/d/1CVpthda3gOVT57nTOfdXjXuAr0vwc5k7avQtDJu-K8I)):
+Participants in the Data Academy Spring Cohort will complete two Skill Paths (view as [weekly spreadsheet](https://docs.google.com/spreadsheets/d/16v4ebouRSNrLmTvqOrgVsvr2DorelZqLvOT4qVYO128/edit?gid=0#gid=0)):
 
 #### [R Basics for Data Analysis](https://www.dataquest.io/path/r-basics-for-data-analysis/) (4 courses)
 
 -   [Introduction to Data Analysis in R](https://www.dataquest.io/course/intro-to-r-rewrite/) (weeks 1-3)
 -   [Data Structures in R](https://www.dataquest.io/course/datastructure-in-r-rewrite/) (weeks 3-7)
--   [Control Flow, Iteration, and Functions in R](https://www.dataquest.io/course/intermediate-r/) (weeks 7-9)
--   [Specialized Data Processing in R](https://www.dataquest.io/course/intermediate-r-part-two/) (weeks 9-11)
+-   [Control Flow, Iteration, and Functions in R](https://www.dataquest.io/course/intermediate-r/) (weeks 8-9)
+-   BREAK WEEK - no new material, catch up on previous weeks, and/or explore other courses in the dataquest.io catalogue (week 10)
+-   [Specialized Data Processing in R](https://www.dataquest.io/course/intermediate-r-part-two/) (weeks 11-12)
 
 #### [Data Visualization with R](https://www.dataquest.io/path/data-visualization-with-r/) (1 course)
 
--   [Introduction to Data Visualization in R](https://www.dataquest.io/course/r-data-viz/) (weeks 11-13)
+-   [Introduction to Data Visualization in R](https://www.dataquest.io/course/r-data-viz/) (weeks 13-15)
 
-During the Data Academy, you will have access to the full dataquest.io library of courses in addition to the R Curriculum. Once you have completed the curriculum for your certificates, we recommend the following additional courses:
+During the Data Academy, you will have access to the [full dataquest.io catalogue of courses](https://www.dataquest.io/catalog/) in addition to the R Curriculum. If you have time after completing the curriculum for your certificates, we recommend the following additional courses:
 
 -   [Introduction to Data Cleaning in R](https://www.dataquest.io/course/r-data-viz-2/)
 -   [Introduction to Git and Version Control](https://www.dataquest.io/course/git-and-vcs/)
@@ -105,8 +68,42 @@ This is a separate program, but part of the broader Openscapes work with NOAA da
 
 **How do I keep up with the material? What if I get stuck?**
 
-While this is an asynchronous training, doing it with other people is valuable for accountability and to help each other when you’re stuck. Openscapes will host an optional weekly 1-hour help desk and coworking session where you can ask questions and we can discuss the material as a cohort.
+While this is an asynchronous training, doing it with other people is valuable for accountability and to help each other when you’re stuck. Openscapes will host an optional weekly 1-hour help desk and coworking session with live demonstrations, where you can ask questions and we can discuss the material as a cohort.
 
 **Will you offer the Data Academy at another time? This conflicts with my field season!**
 
-Choosing a time is hard and we understand this timing will exclude some people; we might be able to start earlier in 2026. Openscapes Champions Cohorts are more intensive and we run those in fall when there are fewer field season conflicts. 
+Choosing a time is hard and we understand this timing will exclude some people; we might also be able to offer it at a different time in the future. Openscapes Champions Cohorts are more intensive and we run those in fall when there are fewer field season conflicts. 
+
+::: {.callout-note collapse="true"}
+
+## Previous Cohorts
+
+### Fall 2025 Cohort
+
+The Fall Cohort was more self-directed and included people who were new to R or had some R experience. Participants chose their own learning paths based on their interests and needs, and/or chose to follow the same [curriculum] as those in the Spring cohort. You can see the suggested curriculum schedule for the Fall cohort in the [curriculum spreadsheet](https://docs.google.com/spreadsheets/d/1YdE_khWiEr46fgdUyAG7GUg6fGBEAgQ9RRl9ac__0hQ).
+
+**When:** Aug 18, 2025 - Apr 10, 2026. 
+
+-   Complete lessons on your own schedule.
+-   Wednesdays: Help desk with the Openscapes team alongside other participants (Optional, via Zoom).
+-   Asynchronous chat and Q&A in the dedicated Google Space.
+
+### Spring 2025 Cohort
+
+The Spring Cohort was designed for absolute beginners to R, and covers the basics of R programming and data visualization. This was a great opportunity for those who were new to R or had limited experience with it. Paricipants followed the [curriculum](https://docs.google.com/spreadsheets/d/1CVpthda3gOVT57nTOfdXjXuAr0vwc5k7avQtDJu-K8I/edit?usp=sharing) and a weekly schedule.
+
+**When**: April 14 - August 14, 2025.
+
+-   Mondays: Week’s lesson reminder received via email. Complete lesson on your own schedule.
+-   Wednesdays: Help desk and coworking with the Openscapes team alongside other participants (Optional, via Zoom).
+-   Asynchronous chat and Q&A in the dedicated Google Space.
+
+#### Selection
+
+The ~~40~~ 80* available spots were distributed across centers and offices. Participants were selected by the Openscapes team with input from NMFS Open Science staff and NMFS Openscapes Mentors.
+
+::: {.callout-note}
+*Due to high demand, we ran the equivalent of two cohorts simultaneously in Spring 2025, for a total of ~80 participants.
+:::
+
+:::

--- a/data-academy.qmd
+++ b/data-academy.qmd
@@ -10,7 +10,7 @@ If you’re interested in participating, please add yourself to the [interest sh
 
 **What:** You will learn R for data science through lessons on the [dataquest.io](http://dataquest.io) platform. See the [curriculum](#curriculum) below. The Data Academy is **asynchronous** so you can complete the lessons on your own schedule, and also **cohort-based** so you’ll get to know your colleagues and have accountability. The Openscapes team will provide support through optional **synchronous help desk hours and coworking** and a **dedicated Google Space** for help. A training certificate will be issued for each module completed.
 
-**Who**: FTEs and Affiliates from any Fisheries office were welcomed to sign up.
+**Who**: FTEs and Affiliates from any Fisheries office are welcome to sign up.
 
 **Expected time commitment**: Weekly for 3 months: 2-3-hour chunks of learning time per week, plus optional 1 hour of support from a "help desk" and coworking.
 


### PR DESCRIPTION
This adds the information for the Spring 2026 Data Academy. 

It links to a new [signup sheet](https://docs.google.com/spreadsheets/d/1Ot92fLTxiP8e3zZfdbF4lnfO8JtR9mhghQ049LoyL4w/edit?gid=0#gid=0) and [curriculum sheet](https://docs.google.com/spreadsheets/d/16v4ebouRSNrLmTvqOrgVsvr2DorelZqLvOT4qVYO128/edit?gid=0#gid=0).

I moved the information about the previous cohorts into a collapsed callout div at the bottom.

Right now I have kept the same 15 week schedule starting April 27, with a break week in week 10, ending the week of Aug 3. This gives three weeks after the final scheduled week of the curriculum until Aug 28 (which is four months from the start of April 27).

Current licenses end April 22. I have written the dates assuming a couple of days to turn over and including the weekend April 25-26. However we did tell the previous group of people that we gave access to that we would end April 10, so we could move the start up to April 20th, but I would like to hear first from dataquest about our renewal options. If we did start a week earlier we could extend the curriculum by a week, giving learners a schedule with a bit more breathing room.

[Direct link to deploy preview page](https://deploy-preview-41--nmfs-openscapes-preview.netlify.app/data-academy)

Ref: https://github.com/nmfs-openscapes/how-we-work/issues/59