### PR TITLE
overwrite PR comment when updating preview

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -38,5 +38,5 @@ jobs:
           enable-pull-request-comment: true
           enable-commit-comment: false
           enable-commit-status: true
-          overwrites-pull-request-comment: false
+          overwrites-pull-request-comment: true
         timeout-minutes: 1


### PR DESCRIPTION
This will make bot comments with the deploy preview link to be overwritten each time the deploy preview is created, so that we don't have a long string of comments from the deploy preview bot